### PR TITLE
docs: add README with summary and links to project management documents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# OctoAcme Project Management Docs — README
+
+Welcome to the hub for OctoAcme’s project management processes! This documentation offers both a quick-start introduction and a deep dive into structured, repeatable ways to deliver successful cross-functional projects at OctoAcme. Whether you are a new contributor or a returning team member, use it to navigate our major workflows, key roles, and process artifacts.
+
+## Overview of Project Management Processes
+
+OctoAcme’s approach centers on delivering measurable value in small, testable increments, guided by clear ownership and data-informed iteration. Every project starts with a focused Initiation phase—defining goals, success metrics, and stakeholders—followed by robust Planning, disciplined Execution, standard Release, and reflective Retrospective stages. Roles are clearly defined: Project Managers coordinate schedules, risks, and communications; Product Managers shape vision and priorities; Developers deliver and test features; dedicated QA ensures acceptance; and Stakeholders guide decisions and validate outcomes.
+
+Our workflows rely on artifacts like one-pagers, release plans, risk registers, and project boards to capture knowledge and track progress. Work items move through visible stages (from Backlog to Done) with Pull Requests tied to acceptance criteria, subject to automated and manual quality checks, and reviewed before merge. Checklists at each stage and a structured approach to risk and dependencies support high-quality, low-drama delivery.
+
+Communication is intentional and routine-driven—standups, regular syncs, stakeholder updates, and scheduled demos keep everyone aligned. Risks are raised and tracked proactively, while blockers follow defined escalation paths to encourage transparency and speed incident resolution. Documentation serves as the single source of truth, keeping all team members and stakeholders grounded in shared understanding.
+
+Continuous improvement underpins all project work at OctoAcme. After each major milestone, teams hold retrospectives to review outcomes, celebrate wins, identify process gaps, and assign actionable improvements—feeding learning and enhancements back into this living documentation. This discipline accelerates onboarding, spreads knowledge, and builds an organizational foundation for repeatable, high-quality project delivery.
+
+## Process Documentation Index
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risks & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+_For details, templates, and checklists, see each document above. Help us keep this resource fresh by proposing improvements as you uncover opportunities!_
+
+---
+_This documentation is a living resource for the OctoAcme team and its contributors._


### PR DESCRIPTION
This adds a new README to the docs/ folder giving an overview of the OctoAcme project management processes, major workflows, and links to all individual process documents.

Closes #2

Reviewer: @oleksii-lymarenko-ext